### PR TITLE
feat(mcp-servers): Allow configurable directories for filesystem server

### DIFF
--- a/mcp_servers/filesystem_server.py
+++ b/mcp_servers/filesystem_server.py
@@ -1,11 +1,21 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-"""Filesystem MCP server — Python equivalent of @modelcontextprotocol/server-filesystem."""
+"""Filesystem MCP server — Python equivalent of @modelcontextprotocol/server-filesystem.
+
+Allowed directories can be configured via command-line arguments:
+    python filesystem_server.py C:\\Users\\Public\\Documents D:\\Data
+
+If no arguments are provided, defaults to C:\\Users\\Public\\Documents.
+"""
 import os
+import sys
 from fastmcp import FastMCP
 
 mcp = FastMCP("filesystem")
-ALLOWED_DIRS = ["C:\\Users\\Public\\Documents"]
+
+# Allowed directories: from CLI args, or default.
+_DEFAULT_DIRS = ["C:\\Users\\Public\\Documents"]
+ALLOWED_DIRS = sys.argv[1:] if len(sys.argv) > 1 else _DEFAULT_DIRS
 
 
 def _validate(path):
@@ -33,8 +43,13 @@ def write_file(path: str, content: str) -> str:
 
 
 @mcp.tool
-def list_directory(path: str = "C:\\Users\\Public\\Documents") -> list:
-    """List directory contents with [FILE] or [DIR] prefix."""
+def list_directory(path: str = "") -> list:
+    """List directory contents with [FILE] or [DIR] prefix.
+
+    If no path is provided, lists the first allowed directory.
+    """
+    if not path:
+        path = ALLOWED_DIRS[0]
     full = _validate(path)
     entries = []
     for entry in os.scandir(full):

--- a/scripts/setup_mcp_redirection.sh
+++ b/scripts/setup_mcp_redirection.sh
@@ -16,15 +16,19 @@
 # Options:
 #   --mcp-endpoint URL         Agent Access MCP endpoint (default: prod)
 #   --region REGION            AWS region (default: us-east-1)
+#   --allowed-dirs DIRS        Comma-separated directories for the filesystem server
+#                              (default: C:\Users\Public\Documents)
 
 set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 MCP_ENDPOINT=""
+ALLOWED_DIRS="C:\\Users\\Public\\Documents"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
     --mcp-endpoint) MCP_ENDPOINT="$2"; shift 2;;
+    --allowed-dirs) ALLOWED_DIRS="$2"; shift 2;;
     --region) REGION="$2"; shift 2;;
     *) echo "Unknown option: $1"; exit 1;;
   esac
@@ -119,7 +123,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Base64 encode server files
 FS_B64=$(base64 -w0 "$SCRIPT_DIR/../mcp_servers/filesystem_server.py")
 FETCH_B64=$(base64 -w0 "$SCRIPT_DIR/../mcp_servers/fetch_server.py")
-MANIFEST='{"mcpServers":{"filesystem":{"command":"C:\\\\Program Files\\\\Python312\\\\python.exe","args":["C:\\\\McpServers\\\\filesystem_server.py"]},"fetch":{"command":"C:\\\\Program Files\\\\Python312\\\\python.exe","args":["C:\\\\McpServers\\\\fetch_server.py"]}}}'
+
+# Build filesystem server args: script path + allowed directories
+# Use forward slashes — cleaner in JSON and Python handles them natively on Windows.
+IFS=',' read -ra DIRS_ARRAY <<< "$ALLOWED_DIRS"
+FS_ARGS="[\"C:/McpServers/filesystem_server.py\""
+for dir in "${DIRS_ARRAY[@]}"; do
+  # Convert backslashes to forward slashes for clean JSON
+  cleaned=$(echo "$dir" | sed 's/\\/\//g')
+  FS_ARGS="$FS_ARGS,\"$cleaned\""
+done
+FS_ARGS="$FS_ARGS]"
+
+MANIFEST="{\"mcpServers\":{\"filesystem\":{\"command\":\"C:/Program Files/Python312/python.exe\",\"args\":$FS_ARGS},\"fetch\":{\"command\":\"C:/Program Files/Python312/python.exe\",\"args\":[\"C:/McpServers/fetch_server.py\"]}}}"
 MANIFEST_B64=$(echo -n "$MANIFEST" | base64 -w0)
 
 CMD_ID=$(aws ssm send-command --region "$REGION" \


### PR DESCRIPTION
## Summary

Makes the forwarded filesystem MCP server's allowed directories configurable instead of hardcoded.

### Changes

**`mcp_servers/filesystem_server.py`:**
- Reads allowed directories from `sys.argv[1:]` at startup
- Falls back to `C:\Users\Public\Documents` if no args provided (backward-compatible)
- `list_directory()` defaults to the first allowed dir instead of a hardcoded path
- Multiple directories supported — each passed as a separate CLI arg

**`scripts/setup_mcp_redirection.sh`:**
- New flag: `--allowed-dirs "C:\Users\Public\Documents,D:\Data"` (comma-separated)
- Builds the manifest `args` array dynamically from the configured dirs
- Default unchanged: `C:\Users\Public\Documents`

### How it works

The MCP server manifest on the image controls what args are passed to the server at launch:
```json
{"mcpServers": {"filesystem": {
  "command": "C:\\Program Files\\Python312\\python.exe",
  "args": ["C:\\McpServers\\filesystem_server.py", "C:\\Users\\Public\\Documents", "D:\\Data"]
}}}
```

Users who build their own images can also edit `C:\ProgramData\NICE\dcv\mcp_server_redirection_config.json` directly — no setup script required.

### Testing
- `python -m py_compile` passes
- `bash -n` on setup script passes
- `./scripts/ci_local.sh` passes
- Not tested against a live fleet (image rebuild required for the manifest change to take effect)