### PR TITLE
feat(utils): Add MCP tool forwarding compatibility tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ To set up a fleet with custom MCP servers (requires ~30 min for AMI build + impo
 
 This builds a Windows Server 2025 image with Python + FastMCP and two example servers (`filesystem`, `fetch`), imports it to WorkSpaces, and creates a fleet with `FORWARD_MCP_TOOLS` enabled. See `mcp_servers/` for the server source code.
 
+> **Validate first:** before building a custom image, check that your MCP servers will forward correctly with the compatibility tester in [`utils/mcpforwardingtester/`](utils/mcpforwardingtester/). It catches the common failures (a server that lists no tools, a config saved with a BOM, or `env`/`cwd` keys that get silently ignored) before the ~30-minute image build.
+
 Once the redirection fleet is running, `agents/mcp_redirection_demo/` drives the forwarded tools end to end — it lists and reads seeded files, fetches a web page, writes a report file, and confirms the result on the desktop:
 
 ```bash
@@ -174,6 +176,8 @@ sample-code-for-workspaces-agent-access/
 │   ├── package.sh              # Create distribution zip
 ├── skills/
 │   └── workspace-skill-creator/  # Skill for creating new app skills
+├── utils/
+│   └── mcpforwardingtester/      # Validate MCP servers forward correctly before building an image
 └── requirements.txt
 ```
 

--- a/utils/mcpforwardingtester/README.md
+++ b/utils/mcpforwardingtester/README.md
@@ -1,0 +1,137 @@
+# MCP Tool Forwarding Compatibility Tester
+
+Verify that the MCP servers you set up for tool forwarding on Amazon WorkSpaces
+Applications work, before you bake them into a fleet image.
+
+When forwarding is enabled, the WorkSpaces Applications MCP server (the "service")
+launches the servers in your config and forwards their tools to your agent. A server
+that runs fine locally can still fail to forward: it may start too slowly, list zero
+tools, or ship a config the service rejects. This tool reproduces how the service
+launches and queries your servers, then reports, per server, what works and what to fix.
+
+For the forwarding feature itself, see the [WorkSpaces Applications MCP server docs](https://docs.aws.amazon.com/appstream2/latest/developerguide/agent-access-mcp-server.html#agent-access-mcp-tool-forwarding-details).
+
+## Install
+
+Requires Python 3.10+. Install it on the WorkSpaces Applications image builder, where
+your MCP server is installed.
+
+On the image builder, in PowerShell:
+
+```powershell
+py -m pip install "https://github.com/aws-samples/sample-code-for-workspaces-agent-access/archive/refs/heads/main.zip#subdirectory=utils/mcpforwardingtester"
+```
+
+For local development, from the repo root, in your terminal:
+
+```bash
+pip install ./utils/mcpforwardingtester
+```
+
+## Usage
+
+On the image builder, in PowerShell, validate the deployed config before you create
+the image. No path is needed; it defaults to the location the service reads:
+
+```powershell
+py -m mcp_forwarding_tester config
+# defaults to C:\ProgramData\NICE\dcv\mcp_server_redirection_config.json
+```
+
+Fix anything it reports, re-run until the verdict is `OK`, then create the image.
+
+Other forms, also in PowerShell on the image builder:
+
+```powershell
+# Point at a specific config file
+py -m mcp_forwarding_tester config C:\ProgramData\NICE\dcv\mcp_server_redirection_config.json
+
+# Test a single server ad hoc (order of --arg is preserved)
+py -m mcp_forwarding_tester server --command C:/Python312/python.exe --arg C:/McpServers/my_server.py
+
+# Opt-in: invoke a tool
+py -m mcp_forwarding_tester server --command C:/McpServers/my_server.exe --call search --args-json '{"q": "hello"}'
+
+# Opt-in: smoke-call every tool that needs no required arguments
+py -m mcp_forwarding_tester config --probe-tools
+
+# Machine-readable output (for a build gate)
+py -m mcp_forwarding_tester config --json
+```
+
+Locally (macOS, Linux, or WSL), swap the Windows `py` launcher for `python`, e.g.
+`python -m mcp_forwarding_tester server --command ./my-server`.
+
+Exit codes: `0` = no failures (warnings allowed), `1` = at least one FAIL, `2` = usage
+or config-load error.
+
+> **Run latency checks on the image builder.** The ~5 s `tools/list` budget only
+> reflects real cold-start cost on an instance, not on a fast laptop. See
+> [Slow servers & the 5 s budget](#slow-servers--the-5-s-budget).
+
+## What it checks
+
+Each check is a requirement your server must meet to forward successfully.
+
+| Check | What must be true |
+| --- | --- |
+| `config.encoding` | The config file is UTF-8 **without a BOM**. Windows editors (Notepad, some PowerShell `Set-Content` calls) add one by default, and the service rejects it. |
+| `config.command` / `config.ignored-keys` | A server entry uses only `command` and `args`. **`env`/`cwd` are ignored** (a common mistake), so it warns. |
+| `spawn` | The server launches from `command` + `args` over stdio. |
+| `initialize` | The MCP handshake completes. |
+| `protocol-version` | Reports the negotiated MCP protocol version (see fidelity note). |
+| `tools-list` | **The server returns ≥1 tool.** A server that lists none is dropped; if no server lists any, forwarding yields no tools. |
+| `tool-names` | Tool names stay unambiguous once namespaced as `forwarded___<server>___<tool>`. |
+| `tools-list-latency` | **Listing tools finishes within ~5 s.** Over the budget the tools are dropped and your agent sees none. |
+| `initialize-latency` | Spawn + `initialize` time (WARN-only; a slow start makes `tools/list` more likely to exceed its budget). |
+| `call:<tool>` | Opt-in: a tool call returns a non-error result within ~5 s. |
+| `aggregate.tools` | At least one tool total across all servers. |
+
+## Slow servers & the 5 s budget
+
+Listing tools (and each tool call) is time-boxed at **5 seconds**, with no setting to
+raise it. A server whose first listing is slow (cold interpreter startup, heavy imports,
+antivirus scanning, or a network call at startup) is cut off, and the agent sees **no
+tools**. A warm retry then works, which can mask the problem.
+
+To fix a slow server: cut startup work, pre-warm it once so imports and AV scans are
+cached, disable telemetry, and make sure any startup network call succeeds fast.
+
+## Setting env vars: use a wrapper
+
+A server entry has only `command` and `args`, so you cannot set environment variables in
+the config. Launch the server through a wrapper script that sets the env and execs it;
+the launched process inherits the wrapper's environment. On Windows, point `command` at
+`cmd.exe /c <wrapper>` (a `.cmd`/`.bat` cannot be exec'd directly), and start the wrapper
+with `@echo off`, or shell echoing will corrupt the JSON-RPC stdout.
+
+```bat
+REM launch-myserver.cmd
+@echo off
+set "MY_ENV_VAR=value"
+"C:\path\to\python.exe" "C:\path\to\myserver.py" %*
+```
+
+```json
+{
+  "mcpServers": {
+    "myserver": {
+      "command": "C:/Windows/System32/cmd.exe",
+      "args": ["/c", "C:/path/to/launch-myserver.cmd"]
+    }
+  }
+}
+```
+
+## Fidelity note
+
+This tool uses the official Python `mcp` SDK to approximate the service's client. The one
+difference worth checking is the negotiated **MCP protocol version** (the tool prints it):
+if your server accepts only one version, confirm it matches what the service negotiates.
+
+## Development
+
+```bash
+pip install -e '.[test]'
+pytest
+```

--- a/utils/mcpforwardingtester/pyproject.toml
+++ b/utils/mcpforwardingtester/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mcp-forwarding-tester"
+version = "0.1.0"
+description = "Test whether an MCP server is compatible with MCP tool forwarding on Amazon WorkSpaces Applications"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT-0"}
+dependencies = ["mcp>=1.9,<2"]
+
+[project.optional-dependencies]
+test = ["pytest>=7", "pytest-asyncio>=0.23"]
+
+[project.scripts]
+mcp-forwarding-test = "mcp_forwarding_tester.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/utils/mcpforwardingtester/src/mcp_forwarding_tester/__init__.py
+++ b/utils/mcpforwardingtester/src/mcp_forwarding_tester/__init__.py
@@ -1,0 +1,10 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Compatibility tester for MCP tool forwarding on Amazon WorkSpaces Applications.
+
+Launches your MCP servers the same way the service does and verifies they meet
+its requirements, so you can confirm before deploying that your servers load and their
+tools reach the connected agent.
+"""
+
+__version__ = "0.1.0"

--- a/utils/mcpforwardingtester/src/mcp_forwarding_tester/__main__.py
+++ b/utils/mcpforwardingtester/src/mcp_forwarding_tester/__main__.py
@@ -1,0 +1,8 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Enable ``python -m mcp_forwarding_tester``."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/mcpforwardingtester/src/mcp_forwarding_tester/checks.py
+++ b/utils/mcpforwardingtester/src/mcp_forwarding_tester/checks.py
@@ -1,0 +1,348 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Compatibility checks. Each turns one forwarding requirement into a PASS/WARN/FAIL result.
+
+Checks are pure functions over a ServerProbe (and ServerSpec); the runner connects and
+populates the probe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from . import contract
+from .client import ServerProbe
+from .config import ForwardingConfig, ServerSpec
+
+
+class Level(str, Enum):
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+    INFO = "INFO"
+
+
+@dataclass
+class CheckResult:
+    id: str
+    level: Level
+    message: str
+    data: dict = field(default_factory=dict)
+
+    @property
+    def is_fail(self) -> bool:
+        return self.level is Level.FAIL
+
+
+# --- File-level (whole config file) ----------------------------------------------
+
+def check_config_file(config: ForwardingConfig) -> list[CheckResult]:
+    """Checks about the config file itself, independent of any single server."""
+    results: list[CheckResult] = []
+
+    if config.bom is not None:
+        # The service's JSON parser rejects a BOM and fails to load the whole config.
+        results.append(
+            CheckResult(
+                "config.encoding",
+                Level.FAIL,
+                f"file starts with a {config.bom} byte-order mark (BOM). The service "
+                "rejects a BOM and would fail to load the entire file. Re-save it as "
+                "UTF-8 without a BOM. PowerShell 7+: "
+                "Set-Content -Path <file> -Value (Get-Content -Raw <file>) -Encoding utf8NoBOM. "
+                "Windows PowerShell 5.1 (its -Encoding utf8 still writes a BOM): "
+                "[IO.File]::WriteAllText('<file>', (Get-Content -Raw '<file>'), "
+                "(New-Object Text.UTF8Encoding $false)). "
+                "Or in VS Code: 'Save with Encoding' -> 'UTF-8'.",
+                {"bom": config.bom},
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                "config.encoding",
+                Level.PASS,
+                "file is UTF-8 without a BOM",
+            )
+        )
+
+    return results
+
+
+# --- Static (per-server entry, no process spawned) -------------------------------
+
+def check_static_server(spec: ServerSpec) -> list[CheckResult]:
+    """Validate a single server entry's shape before launching it."""
+    results: list[CheckResult] = []
+
+    results.append(
+        CheckResult(
+            "config.command",
+            Level.PASS,
+            f"command is set: {spec.command!r}",
+            {"command": spec.command, "args": spec.args},
+        )
+    )
+
+    if spec.ignored_keys:
+        # env/cwd are silently dropped by the service.
+        results.append(
+            CheckResult(
+                "config.ignored-keys",
+                Level.WARN,
+                "the service ignores these keys in a server entry (only "
+                f"'command' and 'args' are honored): {', '.join(sorted(spec.ignored_keys))}",
+                {"ignored": sorted(spec.ignored_keys)},
+            )
+        )
+
+    return results
+
+
+# --- Per-server runtime ----------------------------------------------------------
+
+def check_spawn(probe: ServerProbe) -> CheckResult:
+    if probe.spawned:
+        return CheckResult("spawn", Level.PASS, "process launched from command + args")
+    return CheckResult(
+        "spawn",
+        Level.FAIL,
+        probe.connect_error or "process failed to launch",
+    )
+
+
+def check_initialize(probe: ServerProbe) -> CheckResult:
+    if not probe.spawned:
+        return CheckResult("initialize", Level.FAIL, "skipped: process did not launch")
+    if not probe.initialized:
+        return CheckResult(
+            "initialize",
+            Level.FAIL,
+            probe.connect_error or "MCP initialize handshake did not complete",
+        )
+    return CheckResult(
+        "initialize",
+        Level.PASS,
+        f"initialized; server {probe.server_name or '?'} "
+        f"v{probe.server_version or '?'}",
+        {
+            "server_name": probe.server_name,
+            "server_version": probe.server_version,
+            "capabilities": probe.server_capabilities,
+        },
+    )
+
+
+def check_protocol_version(probe: ServerProbe) -> CheckResult:
+    """Report the negotiated protocol version (INFO, not pass/fail; the service may
+    negotiate a different version)."""
+    if not probe.initialized:
+        return CheckResult(
+            "protocol-version", Level.INFO, "skipped: not initialized"
+        )
+    return CheckResult(
+        "protocol-version",
+        Level.INFO,
+        f"negotiated protocol version {probe.protocol_version!r} "
+        "(note: the service may negotiate a different MCP protocol version; "
+        "confirm your server accepts the version it negotiates)",
+        {"protocol_version": probe.protocol_version},
+    )
+
+
+def check_tools_list(probe: ServerProbe) -> CheckResult:
+    """The service drops a server that lists no tools, and forwards nothing if none do."""
+    if not probe.initialized:
+        return CheckResult("tools-list", Level.FAIL, "skipped: not initialized")
+    if probe.list_error is not None:
+        return CheckResult(
+            "tools-list", Level.FAIL, f"tools/list failed: {probe.list_error}"
+        )
+    n = len(probe.tools)
+    if n == 0:
+        return CheckResult(
+            "tools-list",
+            Level.FAIL,
+            "server returned 0 tools; the service drops a server that lists "
+            "no tools, and forwards nothing if no server has any tools",
+        )
+    return CheckResult(
+        "tools-list",
+        Level.PASS,
+        f"server returned {n} tool(s): {', '.join(t.name for t in probe.tools)}",
+        {"tools": [t.name for t in probe.tools]},
+    )
+
+
+def check_tool_names(probe: ServerProbe, server_name: str) -> CheckResult:
+    """The service does not validate names, but '___' in a name makes the forwarded name ambiguous."""
+    if not probe.tools:
+        return CheckResult("tool-names", Level.INFO, "skipped: no tools to inspect")
+
+    suspicious: list[str] = []
+    long_names: list[str] = []
+    for t in probe.tools:
+        if contract.FORWARD_SEPARATOR in t.name:
+            suspicious.append(t.name)
+        if len(contract.forwarded_tool_name(server_name, t.name)) > 128:
+            long_names.append(t.name)
+
+    if suspicious or long_names:
+        bits = []
+        if suspicious:
+            bits.append(
+                f"contain '{contract.FORWARD_SEPARATOR}': {', '.join(suspicious)}"
+            )
+        if long_names:
+            bits.append(f"forwarded name exceeds 128 chars: {', '.join(long_names)}")
+        return CheckResult(
+            "tool-names",
+            Level.WARN,
+            "some tool names may be problematic once namespaced: " + "; ".join(bits),
+            {"suspicious": suspicious, "long": long_names},
+        )
+    return CheckResult(
+        "tool-names",
+        Level.PASS,
+        "tool names are clean for namespacing as "
+        f"{contract.FORWARD_PREFIX}{contract.FORWARD_SEPARATOR}{server_name}"
+        f"{contract.FORWARD_SEPARATOR}<tool>",
+    )
+
+
+def check_tools_list_latency(probe: ServerProbe) -> CheckResult:
+    """tools/list must complete within the 5 s budget.
+
+    The service bounds only the manifest fetch (tools/list). Over the budget,
+    the call is cancelled and the client sees no tools.
+    """
+    if probe.list_seconds is None:
+        return CheckResult("tools-list-latency", Level.INFO, "skipped: tools/list not reached")
+    secs = probe.list_seconds
+    budget = contract.CALL_TIMEOUT_S
+    data = {"list_seconds": round(secs, 3), "budget_seconds": budget}
+    if secs > budget:
+        return CheckResult(
+            "tools-list-latency",
+            Level.FAIL,
+            f"tools/list took {secs:.2f}s, over the {budget:.0f}s budget; the service "
+            "would cancel the call and the client would see no tools. Reduce "
+            "cold-start cost (see README: slow servers & the 5 s budget).",
+            data,
+        )
+    if secs > budget * 0.6:
+        return CheckResult(
+            "tools-list-latency",
+            Level.WARN,
+            f"tools/list took {secs:.2f}s, close to the {budget:.0f}s budget; a cold "
+            "first call on the instance may be slower and get cancelled.",
+            data,
+        )
+    return CheckResult(
+        "tools-list-latency",
+        Level.PASS,
+        f"tools/list took {secs:.2f}s (budget {budget:.0f}s)",
+        data,
+    )
+
+
+def check_initialize_latency(probe: ServerProbe) -> CheckResult:
+    """Report spawn + initialize time.
+
+    The service does not bound this, so it is WARN-only. A slow handshake makes the
+    cold tools/list more likely to exceed the 5 s budget; common causes are telemetry
+    or socket connects at startup.
+    """
+    if probe.init_seconds is None:
+        return CheckResult("initialize-latency", Level.INFO, "skipped: not initialized")
+    secs = probe.init_seconds
+    threshold = contract.SLOW_INITIALIZE_WARN_S
+    data = {"init_seconds": round(secs, 3), "warn_threshold_seconds": threshold}
+    if secs > threshold:
+        return CheckResult(
+            "initialize-latency",
+            Level.WARN,
+            f"spawn + initialize took {secs:.2f}s (> {threshold:.0f}s). The service "
+            "does not time this out, but a slow startup delays tools and risks the "
+            "cold tools/list exceeding 5 s. Check for telemetry/network or socket "
+            "connects during startup (e.g. set DISABLE_TELEMETRY=true).",
+            data,
+        )
+    return CheckResult(
+        "initialize-latency",
+        Level.PASS,
+        f"spawn + initialize took {secs:.2f}s",
+        data,
+    )
+
+
+def check_tool_call(probe: ServerProbe, tool_name: str) -> CheckResult:
+    """Judge an opt-in active tool invocation."""
+    outcome = probe.calls.get(tool_name)
+    if outcome is None:
+        return CheckResult(
+            f"call:{tool_name}", Level.INFO, "not invoked"
+        )
+    if not outcome.ok:
+        return CheckResult(
+            f"call:{tool_name}",
+            Level.FAIL,
+            f"call raised a protocol/transport error: {outcome.error}",
+        )
+    over = outcome.seconds is not None and outcome.seconds > contract.CALL_TIMEOUT_S
+    if outcome.is_error:
+        level = Level.WARN
+        msg = "tool returned an MCP error result (isError=true)"
+    elif over:
+        level = Level.FAIL
+        msg = f"call took {outcome.seconds:.2f}s, over the {contract.CALL_TIMEOUT_S:.0f}s budget"
+    else:
+        level = Level.PASS
+        msg = f"call returned in {outcome.seconds:.2f}s"
+    return CheckResult(
+        f"call:{tool_name}",
+        level,
+        f"{msg}; content: {outcome.content_summary}",
+        {"seconds": outcome.seconds, "is_error": outcome.is_error},
+    )
+
+
+# --- Config-level aggregate ------------------------------------------------------
+
+def check_aggregate(probes: dict[str, ServerProbe]) -> list[CheckResult]:
+    """Cross-server rule: at least one tool total across all servers."""
+    results: list[CheckResult] = []
+
+    total_tools = sum(len(p.tools) for p in probes.values())
+    if total_tools == 0:
+        results.append(
+            CheckResult(
+                "aggregate.tools",
+                Level.FAIL,
+                "no server returned any tools; the service would fail with "
+                '"No available MCP server to redirect has listed its tools."',
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                "aggregate.tools",
+                Level.PASS,
+                f"{total_tools} tool(s) total across {len(probes)} server(s)",
+                {"total_tools": total_tools},
+            )
+        )
+
+    # Forwarded names are server-prefixed, so cross-server collisions can't happen.
+    if len(probes) > 1:
+        results.append(
+            CheckResult(
+                "aggregate.namespacing",
+                Level.INFO,
+                "the service prefixes every tool with its server name, so "
+                "identical tool names across servers do not collide",
+            )
+        )
+
+    return results

--- a/utils/mcpforwardingtester/src/mcp_forwarding_tester/cli.py
+++ b/utils/mcpforwardingtester/src/mcp_forwarding_tester/cli.py
@@ -1,0 +1,134 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Command-line entry point for the MCP tool forwarding compatibility tester."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+from . import contract, report
+from .config import ConfigError, ForwardingConfig, ServerSpec, load_config
+from .runner import CallRequest, RunOptions, run_config
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mcp-forwarding-test",
+        description=(
+            "Verify that MCP servers work with MCP tool forwarding on WorkSpaces "
+            "Applications. Reproduces how the service launches servers and "
+            "lists/calls their tools."
+        ),
+    )
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    # Shared options for both subcommands.
+    def add_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--call",
+            action="append",
+            default=[],
+            metavar="TOOL",
+            help="invoke this tool (opt-in active test). Repeatable. Pair with "
+            "--args-json positionally in order.",
+        )
+        p.add_argument(
+            "--args-json",
+            action="append",
+            default=[],
+            metavar="JSON",
+            help="JSON object of arguments for the matching --call (by order).",
+        )
+        p.add_argument(
+            "--probe-tools",
+            action="store_true",
+            help="smoke-call every tool whose input schema has no required args.",
+        )
+        p.add_argument("--json", action="store_true", help="emit a machine-readable report.")
+
+    p_config = sub.add_parser(
+        "config",
+        help="test all servers in a forwarding config (mcp_server_redirection_config.json)",
+    )
+    p_config.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        help=f"path to the config (default: {contract.default_config_path()})",
+    )
+    add_common(p_config)
+
+    p_server = sub.add_parser("server", help="test a single ad-hoc server")
+    p_server.add_argument("--command", required=True, help="server executable")
+    p_server.add_argument(
+        "--arg",
+        action="append",
+        default=[],
+        dest="args",
+        metavar="ARG",
+        help="one argument to the server command (repeatable, order preserved).",
+    )
+    p_server.add_argument(
+        "--name", default="adhoc", help="logical server name for namespacing (default: adhoc)"
+    )
+    add_common(p_server)
+
+    return parser
+
+
+def _parse_calls(call_names: list[str], args_jsons: list[str]) -> list[CallRequest]:
+    calls: list[CallRequest] = []
+    for i, name in enumerate(call_names):
+        arguments: dict | None = None
+        if i < len(args_jsons):
+            try:
+                arguments = json.loads(args_jsons[i])
+            except json.JSONDecodeError as exc:
+                raise SystemExit(
+                    f"--args-json #{i + 1} for --call {name} is not valid JSON: {exc}"
+                )
+            if not isinstance(arguments, dict):
+                raise SystemExit(f"--args-json #{i + 1} must be a JSON object")
+        calls.append(CallRequest(tool=name, arguments=arguments))
+    return calls
+
+
+def _load(ns: argparse.Namespace) -> ForwardingConfig:
+    if ns.mode == "config":
+        path = ns.path or contract.default_config_path()
+        return load_config(path)
+    # ad-hoc single server
+    spec = ServerSpec(name=ns.name, command=ns.command, args=list(ns.args))
+    return ForwardingConfig(servers=[spec], source="<command-line>")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    ns = parser.parse_args(argv)
+
+    try:
+        config = _load(ns)
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return report.EXIT_USAGE
+
+    opts = RunOptions(
+        calls=_parse_calls(ns.call, ns.args_json),
+        probe_tools=ns.probe_tools,
+    )
+
+    result = asyncio.run(run_config(config, opts))
+
+    if ns.json:
+        report.render_json(result)
+    else:
+        report.render_text(result)
+
+    return report.exit_code(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/mcpforwardingtester/src/mcp_forwarding_tester/client.py
+++ b/utils/mcpforwardingtester/src/mcp_forwarding_tester/client.py
@@ -1,0 +1,219 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""stdio MCP client that mimics how the service connects to servers.
+
+Spawns a stdio child, uses a default MCP client (no roots/sampling/elicitation),
+inherits the full environment, and lists tools with pagination. Main divergence from
+the service: the negotiated protocol version.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+@dataclass
+class ServerProbe:
+    """Everything we learned by connecting to one server, for the checks to judge."""
+
+    # Connection outcome.
+    spawned: bool = False
+    initialized: bool = False
+    connect_error: str | None = None
+
+    # Handshake results.
+    protocol_version: str | None = None
+    server_name: str | None = None
+    server_version: str | None = None
+    server_capabilities: list[str] = field(default_factory=list)
+    instructions: str | None = None
+
+    # Tool discovery (names as the server reports them, before namespacing).
+    tools: list["ToolInfo"] = field(default_factory=list)
+    list_error: str | None = None
+
+    # Timings, seconds.
+    init_seconds: float | None = None
+    list_seconds: float | None = None
+
+    # Active tool-call results, keyed by tool name.
+    calls: dict[str, "CallOutcome"] = field(default_factory=dict)
+
+    # stderr captured during the session (the service inherits stderr; we surface it).
+    stderr_tail: str | None = None
+
+
+@dataclass
+class ToolInfo:
+    name: str
+    description: str | None
+    input_schema: dict | None
+
+
+@dataclass
+class CallOutcome:
+    ok: bool
+    is_error: bool  # the MCP ``isError`` result flag
+    seconds: float | None
+    error: str | None
+    content_summary: str | None
+
+
+# The service inherits the full parent environment. The Python SDK default
+# scrubs it to a subset, so we pass the full environment to match.
+def _full_env() -> dict[str, str]:
+    return dict(os.environ)
+
+
+_STDERR_TAIL_LIMIT = 2000
+
+
+@asynccontextmanager
+async def connect(command: str, args: list[str]):
+    """Open a session the way the service would. Yields (ServerProbe, ClientSession|None).
+
+    The probe is always yielded so callers can inspect partial results on failure.
+    The child's stderr is captured into ``probe.stderr_tail``.
+    """
+    probe = ServerProbe()
+
+    # command + args only (the config has no env/cwd). Pass the full environment so
+    # PATH-resolved commands behave as they do on the instance.
+    params = StdioServerParameters(command=command, args=args, env=_full_env())
+
+    # stdio_client writes to this fd directly, so it must be a real file (needs fileno()).
+    errlog = tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace")
+    try:
+        try:
+            async with stdio_client(params, errlog=errlog) as (read, write):
+                probe.spawned = True
+                # No callbacks => no client capabilities advertised, matching the service.
+                async with ClientSession(read, write) as session:
+                    yield probe, session
+        except Exception as exc:  # noqa: BLE001
+            if not probe.spawned:
+                probe.connect_error = f"failed to spawn '{command}': {exc}"
+            elif not probe.initialized:
+                probe.connect_error = f"session error before/at initialize: {exc}"
+            else:
+                probe.connect_error = f"session error: {exc}"
+            yield probe, None
+    finally:
+        probe.stderr_tail = _read_tail(errlog)
+        errlog.close()
+
+
+def _read_tail(fileobj) -> str | None:
+    try:
+        fileobj.flush()
+        fileobj.seek(0)
+        text = fileobj.read().strip()
+    except (OSError, ValueError):
+        return None
+    if not text:
+        return None
+    return text if len(text) <= _STDERR_TAIL_LIMIT else "..." + text[-_STDERR_TAIL_LIMIT:]
+
+
+async def initialize(probe: ServerProbe, session: ClientSession) -> None:
+    """Run the handshake and record the negotiated protocol + server info."""
+    start = time.monotonic()
+    result = await session.initialize()
+    probe.init_seconds = time.monotonic() - start
+    probe.initialized = True
+
+    probe.protocol_version = getattr(result, "protocolVersion", None)
+    info = getattr(result, "serverInfo", None)
+    if info is not None:
+        probe.server_name = getattr(info, "name", None)
+        probe.server_version = getattr(info, "version", None)
+    probe.instructions = getattr(result, "instructions", None)
+
+    caps = getattr(result, "capabilities", None)
+    if caps is not None:
+        for field_name in ("tools", "resources", "prompts", "logging", "completions"):
+            if getattr(caps, field_name, None) is not None:
+                probe.server_capabilities.append(field_name)
+
+
+async def list_tools_paginated(probe: ServerProbe, session: ClientSession) -> None:
+    """List all tools, following ``nextCursor``, as the service does."""
+    start = time.monotonic()
+    try:
+        cursor: str | None = None
+        collected: list[ToolInfo] = []
+        seen_cursors: set[str] = set()
+        while True:
+            result = await session.list_tools(cursor=cursor)
+            for tool in result.tools:
+                collected.append(
+                    ToolInfo(
+                        name=tool.name,
+                        description=getattr(tool, "description", None),
+                        input_schema=getattr(tool, "inputSchema", None),
+                    )
+                )
+            cursor = getattr(result, "nextCursor", None)
+            if not cursor or cursor in seen_cursors:
+                break
+            seen_cursors.add(cursor)
+        probe.tools = collected
+    except Exception as exc:  # noqa: BLE001
+        probe.list_error = str(exc)
+    finally:
+        probe.list_seconds = time.monotonic() - start
+
+
+def _summarize_content(result) -> str:
+    """Produce a short human summary of a CallToolResult's content blocks."""
+    blocks = getattr(result, "content", None) or []
+    parts: list[str] = []
+    for block in blocks:
+        btype = getattr(block, "type", "?")
+        if btype == "text":
+            text = getattr(block, "text", "") or ""
+            parts.append(text if len(text) <= 200 else text[:197] + "...")
+        else:
+            parts.append(f"<{btype}>")
+    structured = getattr(result, "structuredContent", None)
+    if structured is not None and not parts:
+        return f"<structured: {structured!r}>"
+    return " | ".join(parts) if parts else "<no content>"
+
+
+async def call_tool(
+    probe: ServerProbe,
+    session: ClientSession,
+    name: str,
+    arguments: dict | None,
+) -> CallOutcome:
+    """Invoke a tool and record the outcome under ``probe.calls[name]``."""
+    start = time.monotonic()
+    try:
+        result = await session.call_tool(name, arguments=arguments or {})
+        seconds = time.monotonic() - start
+        is_error = bool(getattr(result, "isError", False))
+        outcome = CallOutcome(
+            ok=True,
+            is_error=is_error,
+            seconds=seconds,
+            error=None,
+            content_summary=_summarize_content(result),
+        )
+    except Exception as exc:  # noqa: BLE001
+        outcome = CallOutcome(
+            ok=False,
+            is_error=True,
+            seconds=time.monotonic() - start,
+            error=str(exc),
+            content_summary=None,
+        )
+    probe.calls[name] = outcome
+    return outcome

--- a/utils/mcpforwardingtester/src/mcp_forwarding_tester/config.py
+++ b/utils/mcpforwardingtester/src/mcp_forwarding_tester/config.py
@@ -1,0 +1,139 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Load and statically validate an MCP tool forwarding config.
+
+Lenient like the service's parser: unknown keys don't stop the load but are
+recorded so we can warn (``env``/``cwd`` are silently dropped).
+"""
+
+from __future__ import annotations
+
+import codecs
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Byte-order marks, checked longest-first so a UTF-32-LE file (FF FE 00 00) is not
+# mis-detected as UTF-16-LE (FF FE). The service expects plain UTF-8 with no BOM.
+_BOMS: tuple[tuple[bytes, str, str], ...] = (
+    (codecs.BOM_UTF32_LE, "UTF-32-LE", "utf-32"),
+    (codecs.BOM_UTF32_BE, "UTF-32-BE", "utf-32"),
+    (codecs.BOM_UTF8, "UTF-8", "utf-8-sig"),
+    (codecs.BOM_UTF16_LE, "UTF-16-LE", "utf-16"),
+    (codecs.BOM_UTF16_BE, "UTF-16-BE", "utf-16"),
+)
+
+from .contract import (
+    CONFIG_TOP_LEVEL_KEY,
+    SERVER_KNOWN_KEYS,
+)
+
+
+class ConfigError(Exception):
+    """Raised when a config cannot be parsed into the forwarding config shape at all."""
+
+
+@dataclass
+class ServerSpec:
+    """One entry of ``mcpServers``: a single MCP server the service would launch."""
+
+    name: str
+    command: str
+    args: list[str] = field(default_factory=list)
+    # Keys present in the JSON entry that the service ignores (e.g. "env", "cwd").
+    ignored_keys: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ForwardingConfig:
+    servers: list[ServerSpec]
+    source: str  # path or "<command-line>"
+    # BOM found at the start of the file, if any (e.g. "UTF-8"). The service
+    # rejects a BOM (reported as FAIL); the tester strips it to keep checking the rest.
+    bom: str | None = None
+
+
+def _decode_config_bytes(data: bytes) -> tuple[str, str | None]:
+    """Decode raw config bytes to text, returning (text, bom_name).
+
+    A leading BOM is stripped so the remaining checks can still run, but its presence
+    is reported so the caller can flag it; the service would fail to load the
+    file at all.
+    """
+    for marker, name, encoding in _BOMS:
+        if data.startswith(marker):
+            return data.decode(encoding), name
+    return data.decode("utf-8"), None
+
+
+def load_config(path: str | Path) -> ForwardingConfig:
+    """Parse a ``mcp_server_redirection_config.json`` file.
+
+    Raises ConfigError if the file is missing, not decodable, not JSON, or not shaped
+    like a forwarding config. Per-server field problems are surfaced as checks later,
+    not raised here, except where the entry is so malformed the parser would reject the
+    whole file. A BOM is recorded (not raised) so the report can explain it.
+    """
+    path = Path(path)
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise ConfigError(f"cannot read config file '{path}': {exc}") from exc
+
+    try:
+        raw, bom = _decode_config_bytes(data)
+    except UnicodeDecodeError as exc:
+        raise ConfigError(f"config file '{path}' is not valid UTF-8 text: {exc}") from exc
+
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"config file '{path}' is not valid JSON: {exc}") from exc
+
+    config = _parse_doc(doc, source=str(path))
+    config.bom = bom
+    return config
+
+
+def parse_config_obj(doc: object, source: str) -> ForwardingConfig:
+    """Validate an already-decoded config object (used by tests)."""
+    return _parse_doc(doc, source=source)
+
+
+def _parse_doc(doc: object, source: str) -> ForwardingConfig:
+    if not isinstance(doc, dict):
+        raise ConfigError("config root must be a JSON object")
+
+    servers_obj = doc.get(CONFIG_TOP_LEVEL_KEY)
+    if servers_obj is None:
+        raise ConfigError(f"config is missing the required '{CONFIG_TOP_LEVEL_KEY}' object")
+    if not isinstance(servers_obj, dict):
+        raise ConfigError(f"'{CONFIG_TOP_LEVEL_KEY}' must be a JSON object of server entries")
+
+    servers: list[ServerSpec] = []
+    for name, entry in servers_obj.items():
+        servers.append(_parse_server(name, entry))
+
+    return ForwardingConfig(servers=servers, source=source)
+
+
+def _parse_server(name: str, entry: object) -> ServerSpec:
+    if not isinstance(entry, dict):
+        # The parser would fail to deserialize this into the server config.
+        raise ConfigError(f"server '{name}': entry must be a JSON object")
+
+    command = entry.get("command")
+    if not isinstance(command, str) or not command:
+        # ``command`` is required and typed as a string in the server config.
+        raise ConfigError(f"server '{name}': missing or non-string 'command'")
+
+    args_val = entry.get("args")
+    args: list[str] = []
+    if args_val is not None:
+        if not isinstance(args_val, list) or not all(isinstance(a, str) for a in args_val):
+            raise ConfigError(f"server '{name}': 'args' must be an array of strings")
+        args = list(args_val)
+
+    ignored = [k for k in entry.keys() if k not in SERVER_KNOWN_KEYS]
+
+    return ServerSpec(name=name, command=command, args=args, ignored_keys=ignored)

--- a/utils/mcpforwardingtester/src/mcp_forwarding_tester/contract.py
+++ b/utils/mcpforwardingtester/src/mcp_forwarding_tester/contract.py
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""MCP tool forwarding contract constants: the requirements the service enforces."""
+
+from __future__ import annotations
+
+import sys
+
+# --- Timeouts (the service's manifest fetch and tool calls) --------------
+# The service wraps tools/list and each tool call in this timeout; past it
+# the call is cancelled and the client gets no tools. It does NOT bound spawn +
+# initialize.
+CALL_TIMEOUT_S: float = 5.0
+# Whole-environment teardown budget.
+TEARDOWN_TIMEOUT_S: float = 15.0
+# Per-server graceful close on teardown.
+GRACEFUL_SHUTDOWN_S: float = 1.0
+# Advisory threshold for a slow spawn + initialize. The service does not bound
+# this, but a slow handshake makes the cold tools/list more likely to exceed
+# CALL_TIMEOUT_S. WARN only, never FAIL.
+SLOW_INITIALIZE_WARN_S: float = 5.0
+
+# --- Tool namespacing (the service) --------------------------------------
+# Every tool is re-exposed under this name. The service does no name validation,
+# but a tool name containing "___" makes the forwarded name ambiguous.
+FORWARD_SEPARATOR: str = "___"
+FORWARD_PREFIX: str = "forwarded"
+
+
+def forwarded_tool_name(server: str, tool: str) -> str:
+    """Reproduce how the service names a forwarded tool."""
+    return f"{FORWARD_PREFIX}{FORWARD_SEPARATOR}{server}{FORWARD_SEPARATOR}{tool}"
+
+
+# --- Config schema (the service's manifest parser) -----------------------
+# A server entry honors ONLY these fields; anything else (notably ``env`` and
+# ``cwd``) is silently ignored.
+CONFIG_TOP_LEVEL_KEY: str = "mcpServers"
+SERVER_REQUIRED_KEYS: tuple[str, ...] = ("command",)
+SERVER_OPTIONAL_KEYS: tuple[str, ...] = ("args",)
+SERVER_KNOWN_KEYS: frozenset[str] = frozenset(SERVER_REQUIRED_KEYS + SERVER_OPTIONAL_KEYS)
+CONFIG_FILE_NAME: str = "mcp_server_redirection_config.json"
+
+
+def default_config_path() -> str:
+    """Return the default config path the service reads for the current OS."""
+    if sys.platform == "win32":
+        return rf"C:\ProgramData\NICE\dcv\{CONFIG_FILE_NAME}"
+    return f"/etc/dcv/{CONFIG_FILE_NAME}"

--- a/utils/mcpforwardingtester/src/mcp_forwarding_tester/report.py
+++ b/utils/mcpforwardingtester/src/mcp_forwarding_tester/report.py
@@ -1,0 +1,138 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Render a ConfigReport as human-readable text or JSON, and decide the exit code."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from .checks import Level
+from .runner import ConfigReport, ServerReport
+
+# Exit-code policy.
+EXIT_OK = 0
+EXIT_FAIL = 1
+EXIT_USAGE = 2
+
+_COLORS = {
+    Level.PASS: "\033[32m",   # green
+    Level.WARN: "\033[33m",   # yellow
+    Level.FAIL: "\033[31m",   # red
+    Level.INFO: "\033[36m",   # cyan
+}
+_RESET = "\033[0m"
+
+
+def _stream_supports_color(stream) -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    if not (hasattr(stream, "isatty") and stream.isatty()):
+        return False
+    if sys.platform == "win32":
+        # Legacy Windows consoles (e.g. Windows PowerShell 5.1 / conhost) do not
+        # interpret ANSI escapes and would print them literally. Only enable color on
+        # terminals known to support VT sequences.
+        return bool(
+            os.environ.get("WT_SESSION")
+            or os.environ.get("ANSICON")
+            or os.environ.get("TERM")
+        )
+    return True
+
+
+def _tag(level: Level, color: bool) -> str:
+    label = f"{level.value:>4}"
+    if color:
+        return f"{_COLORS[level]}{label}{_RESET}"
+    return label
+
+
+def render_text(report: ConfigReport, stream=sys.stdout) -> None:
+    color = _stream_supports_color(stream)
+    w = stream.write
+
+    w("\nMCP tool forwarding compatibility report\n")
+    w(f"source: {report.source}\n")
+    w("=" * 72 + "\n")
+
+    if report.file_checks:
+        w("Config file:\n")
+        for c in report.file_checks:
+            w(f"  [{_tag(c.level, color)}] {c.id}: {c.message}\n")
+
+    for srv in report.servers:
+        _render_server(srv, w, color)
+
+    w("\n" + "-" * 72 + "\n")
+    w("Aggregate (whole config):\n")
+    for c in report.aggregate:
+        w(f"  [{_tag(c.level, color)}] {c.id}: {c.message}\n")
+
+    verdict = "INCOMPATIBLE" if report.failed else "OK"
+    vlevel = Level.FAIL if report.failed else Level.PASS
+    w("\n" + "=" * 72 + "\n")
+    w(f"Verdict: [{_tag(vlevel, color)}] {verdict}\n")
+    if report.failed:
+        w("One or more checks FAILED; this config would not work as intended "
+          "with MCP tool forwarding.\n")
+    else:
+        w("No failures. Warnings (if any) are worth reviewing but are not blocking.\n")
+    w("\n")
+
+
+def _render_server(srv: ServerReport, w, color: bool) -> None:
+    w(f"\nServer '{srv.name}'  (command: {srv.spec.command} "
+      f"{' '.join(srv.spec.args)})\n")
+    probe = srv.probe
+    if probe.protocol_version or probe.server_name:
+        w(f"  server: {probe.server_name or '?'} v{probe.server_version or '?'} | "
+          f"protocol: {probe.protocol_version or '?'}\n")
+    for c in srv.results:
+        w(f"  [{_tag(c.level, color)}] {c.id}: {c.message}\n")
+    if probe.stderr_tail:
+        w("  --- server stderr (the service inherits this) ---\n")
+        for line in probe.stderr_tail.splitlines():
+            w(f"    {line}\n")
+
+
+def render_json(report: ConfigReport, stream=sys.stdout) -> None:
+    doc = {
+        "source": report.source,
+        "failed": report.failed,
+        "file_checks": [
+            {"id": c.id, "level": c.level.value, "message": c.message, "data": c.data}
+            for c in report.file_checks
+        ],
+        "servers": [
+            {
+                "name": s.name,
+                "command": s.spec.command,
+                "args": s.spec.args,
+                "ignored_config_keys": s.spec.ignored_keys,
+                "server_info": {
+                    "name": s.probe.server_name,
+                    "version": s.probe.server_version,
+                    "protocol_version": s.probe.protocol_version,
+                    "capabilities": s.probe.server_capabilities,
+                },
+                "tools": [t.name for t in s.probe.tools],
+                "checks": [
+                    {"id": c.id, "level": c.level.value, "message": c.message, "data": c.data}
+                    for c in s.results
+                ],
+            }
+            for s in report.servers
+        ],
+        "aggregate": [
+            {"id": c.id, "level": c.level.value, "message": c.message, "data": c.data}
+            for c in report.aggregate
+        ],
+    }
+    json.dump(doc, stream, indent=2)
+    stream.write("\n")
+
+
+def exit_code(report: ConfigReport) -> int:
+    return EXIT_FAIL if report.failed else EXIT_OK

--- a/utils/mcpforwardingtester/src/mcp_forwarding_tester/runner.py
+++ b/utils/mcpforwardingtester/src/mcp_forwarding_tester/runner.py
@@ -1,0 +1,137 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Async orchestration: connect to each server, run the checks, aggregate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from . import checks, client
+from .checks import CheckResult, Level
+from .client import ServerProbe
+from .config import ForwardingConfig, ServerSpec
+
+
+@dataclass
+class CallRequest:
+    tool: str
+    arguments: dict | None = None
+
+
+@dataclass
+class RunOptions:
+    # Active invocation (opt-in).
+    calls: list[CallRequest] = field(default_factory=list)
+    # Smoke-call every tool whose input schema has no required properties.
+    probe_tools: bool = False
+
+
+@dataclass
+class ServerReport:
+    name: str
+    spec: ServerSpec
+    probe: ServerProbe
+    results: list[CheckResult]
+
+    @property
+    def worst(self) -> Level:
+        return _worst([r.level for r in self.results])
+
+
+@dataclass
+class ConfigReport:
+    source: str
+    servers: list[ServerReport]
+    aggregate: list[CheckResult]
+    # Checks about the config file itself (e.g. encoding/BOM). Empty for ad-hoc runs.
+    file_checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def failed(self) -> bool:
+        if any(r.is_fail for r in self.file_checks):
+            return True
+        if any(r.is_fail for r in self.aggregate):
+            return True
+        return any(any(c.is_fail for c in s.results) for s in self.servers)
+
+
+def _worst(levels: list[Level]) -> Level:
+    order = {Level.INFO: 0, Level.PASS: 1, Level.WARN: 2, Level.FAIL: 3}
+    return max(levels, key=lambda lv: order[lv], default=Level.PASS)
+
+
+def _schema_has_no_required_args(schema: dict | None) -> bool:
+    if not schema:
+        return True
+    required = schema.get("required")
+    return not required
+
+
+async def run_server(spec: ServerSpec, opts: RunOptions) -> ServerReport:
+    """Connect to one server and evaluate the full per-server check suite."""
+    results: list[CheckResult] = list(checks.check_static_server(spec))
+
+    async with client.connect(spec.command, spec.args) as (probe, session):
+        if session is not None:
+            try:
+                await client.initialize(probe, session)
+                if probe.initialized:
+                    await client.list_tools_paginated(probe, session)
+                    await _run_calls(probe, session, opts)
+            except Exception as exc:  # noqa: BLE001
+                if probe.connect_error is None:
+                    probe.connect_error = f"unexpected error during session: {exc}"
+
+    results.extend(_evaluate(spec, probe, opts))
+    return ServerReport(name=spec.name, spec=spec, probe=probe, results=results)
+
+
+async def _run_calls(
+    probe: ServerProbe, session, opts: RunOptions
+) -> None:
+    # Explicit calls requested on the command line.
+    for req in opts.calls:
+        await client.call_tool(probe, session, req.tool, req.arguments)
+    # Auto-probe no-arg tools if asked.
+    if opts.probe_tools:
+        for tool in probe.tools:
+            if tool.name in probe.calls:
+                continue
+            if _schema_has_no_required_args(tool.input_schema):
+                await client.call_tool(probe, session, tool.name, {})
+
+
+def _evaluate(spec: ServerSpec, probe: ServerProbe, opts: RunOptions) -> list[CheckResult]:
+    results: list[CheckResult] = [
+        checks.check_spawn(probe),
+        checks.check_initialize(probe),
+        checks.check_protocol_version(probe),
+        checks.check_tools_list(probe),
+        checks.check_tool_names(probe, spec.name),
+        checks.check_initialize_latency(probe),
+        checks.check_tools_list_latency(probe),
+    ]
+    for tool_name in probe.calls:
+        results.append(checks.check_tool_call(probe, tool_name))
+    return results
+
+
+async def run_config(config: ForwardingConfig, opts: RunOptions) -> ConfigReport:
+    """Evaluate every server in a config and compute the cross-server aggregate."""
+    file_checks = checks.check_config_file(config)
+
+    server_reports: list[ServerReport] = []
+    probes: dict[str, ServerProbe] = {}
+    # Sequential; configs are small.
+    for spec in config.servers:
+        report = await run_server(spec, opts)
+        server_reports.append(report)
+        probes[spec.name] = report.probe
+
+    aggregate = checks.check_aggregate(probes)
+    return ConfigReport(
+        source=config.source,
+        servers=server_reports,
+        aggregate=aggregate,
+        file_checks=file_checks,
+    )

--- a/utils/mcpforwardingtester/tests/fixtures/good_config.json
+++ b/utils/mcpforwardingtester/tests/fixtures/good_config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "/usr/local/bin/mcp-server-filesystem",
+      "args": ["--root", "/home/appuser"]
+    },
+    "weather": {
+      "command": "/opt/mcp/weather"
+    }
+  }
+}

--- a/utils/mcpforwardingtester/tests/fixtures/stub_server.py
+++ b/utils/mcpforwardingtester/tests/fixtures/stub_server.py
@@ -1,0 +1,89 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""A tiny stdio MCP server used as a known-good reference in the test suite.
+
+Run modes (selected by the first CLI arg, default "good"):
+  good       - exposes two trivial tools ("echo", "ping"); the happy path.
+  empty      - exposes no tools; exercises the zero-tools FAIL path.
+  slow-init  - sleeps before serving, simulating a slow spawn + initialize
+               (the service does not time this out, so the tester should
+               WARN, not FAIL).
+  slow-list  - answers tools/list slowly, simulating a cold first list that blows
+               the 5 s budget (the tester should FAIL tools-list-latency).
+
+An optional second arg overrides the delay in seconds (default 6, comfortably over
+the 5 s budget). The simple modes use FastMCP; slow-list uses the low-level Server so
+it can intercept the tools/list handler.
+"""
+
+import sys
+import time
+
+mode = sys.argv[1] if len(sys.argv) > 1 else "good"
+delay = float(sys.argv[2]) if len(sys.argv) > 2 else 6.0
+
+
+def run_fastmcp(with_tools: bool) -> None:
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("forwarding-stub-server")
+
+    if with_tools:
+
+        @mcp.tool()
+        def echo(text: str) -> str:
+            """Return the text it was given."""
+            return text
+
+        @mcp.tool()
+        def ping() -> str:
+            """Return 'pong', a no-argument tool for --probe-tools."""
+            return "pong"
+
+    mcp.run()
+
+
+def run_slow_list(delay_s: float) -> None:
+    import anyio
+    import mcp.types as types
+    from mcp.server.lowlevel import Server
+    from mcp.server.stdio import stdio_server
+
+    server = Server("forwarding-stub-server")
+
+    @server.list_tools()
+    async def list_tools() -> list[types.Tool]:
+        # Simulate an expensive cold first listing.
+        await anyio.sleep(delay_s)
+        return [
+            types.Tool(
+                name="echo",
+                description="Return the text it was given.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            )
+        ]
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+        return [types.TextContent(type="text", text=str(arguments.get("text", "")))]
+
+    async def main() -> None:
+        async with stdio_server() as (read, write):
+            await server.run(read, write, server.create_initialization_options())
+
+    anyio.run(main)
+
+
+if __name__ == "__main__":
+    if mode == "slow-init":
+        # Block before we start serving: spawn + initialize appears slow.
+        time.sleep(delay)
+        run_fastmcp(with_tools=True)
+    elif mode == "slow-list":
+        run_slow_list(delay)
+    else:
+        run_fastmcp(with_tools=(mode != "empty"))

--- a/utils/mcpforwardingtester/tests/test_config.py
+++ b/utils/mcpforwardingtester/tests/test_config.py
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Static config-validation unit tests (no process spawned)."""
+
+from pathlib import Path
+
+import pytest
+
+from mcp_forwarding_tester.config import (
+    ConfigError,
+    load_config,
+    parse_config_obj,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_good_config_parses():
+    cfg = load_config(FIXTURES / "good_config.json")
+    names = {s.name for s in cfg.servers}
+    assert names == {"filesystem", "weather"}
+    fs = next(s for s in cfg.servers if s.name == "filesystem")
+    assert fs.command == "/usr/local/bin/mcp-server-filesystem"
+    assert fs.args == ["--root", "/home/appuser"]
+    weather = next(s for s in cfg.servers if s.name == "weather")
+    assert weather.args == []
+    assert fs.ignored_keys == []
+
+
+def test_ignored_keys_detected():
+    doc = {
+        "mcpServers": {
+            "s": {"command": "/bin/true", "env": {"X": "1"}, "cwd": "/tmp"}
+        }
+    }
+    cfg = parse_config_obj(doc, source="<test>")
+    spec = cfg.servers[0]
+    assert set(spec.ignored_keys) == {"env", "cwd"}
+    assert spec.command == "/bin/true"
+
+
+def test_missing_top_level_key():
+    with pytest.raises(ConfigError):
+        parse_config_obj({"servers": {}}, source="<test>")
+
+
+def test_missing_command():
+    with pytest.raises(ConfigError):
+        parse_config_obj({"mcpServers": {"s": {"args": ["x"]}}}, source="<test>")
+
+
+def test_bad_args_type():
+    with pytest.raises(ConfigError):
+        parse_config_obj(
+            {"mcpServers": {"s": {"command": "/bin/true", "args": "x"}}},
+            source="<test>",
+        )
+
+
+def test_non_object_root():
+    with pytest.raises(ConfigError):
+        parse_config_obj([], source="<test>")
+
+
+def test_invalid_json_file(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{not json")
+    with pytest.raises(ConfigError):
+        load_config(p)
+
+
+def test_missing_file(tmp_path):
+    with pytest.raises(ConfigError):
+        load_config(tmp_path / "nope.json")
+
+
+def test_utf8_bom_is_detected_not_fatal(tmp_path):
+    # A UTF-8 BOM must NOT crash the loader: the service rejects it, but the
+    # tester strips it so it can still run the rest of the checks. The BOM is recorded
+    # for the report.
+    p = tmp_path / "bom.json"
+    p.write_text('{"mcpServers": {"s": {"command": "/bin/true"}}}', encoding="utf-8-sig")
+    cfg = load_config(p)
+    assert cfg.bom == "UTF-8"
+    assert [s.name for s in cfg.servers] == ["s"]
+
+
+def test_no_bom_reports_none(tmp_path):
+    p = tmp_path / "clean.json"
+    p.write_text('{"mcpServers": {"s": {"command": "/bin/true"}}}', encoding="utf-8")
+    cfg = load_config(p)
+    assert cfg.bom is None
+
+
+def test_bom_check_fails(tmp_path):
+    # The config.encoding check should FAIL when a BOM is present.
+    from mcp_forwarding_tester.checks import Level, check_config_file
+
+    p = tmp_path / "bom.json"
+    p.write_text('{"mcpServers": {"s": {"command": "/bin/true"}}}', encoding="utf-8-sig")
+    cfg = load_config(p)
+    results = check_config_file(cfg)
+    enc = next(c for c in results if c.id == "config.encoding")
+    assert enc.level is Level.FAIL

--- a/utils/mcpforwardingtester/tests/test_runner_stub.py
+++ b/utils/mcpforwardingtester/tests/test_runner_stub.py
@@ -1,0 +1,118 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""End-to-end tests that launch the bundled stub MCP server.
+
+These require the ``mcp`` SDK (a runtime dependency) and spawn a real child process,
+so they exercise the same path the service uses: spawn -> initialize -> list -> call.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from mcp_forwarding_tester.checks import Level
+from mcp_forwarding_tester.config import ForwardingConfig, ServerSpec
+from mcp_forwarding_tester.runner import CallRequest, RunOptions, run_config
+
+FIXTURES = Path(__file__).parent / "fixtures"
+STUB = str(FIXTURES / "stub_server.py")
+
+
+def _check(report_servers, server_name, check_id):
+    srv = next(s for s in report_servers if s.name == server_name)
+    return next(c for c in srv.results if c.id == check_id)
+
+
+def _config(spec: ServerSpec) -> ForwardingConfig:
+    return ForwardingConfig(servers=[spec], source="<test>")
+
+
+@pytest.mark.asyncio
+async def test_good_server_passes():
+    spec = ServerSpec(name="stub", command=sys.executable, args=[STUB, "good"])
+    report = await run_config(_config(spec), RunOptions())
+
+    assert _check(report.servers, "stub", "spawn").level is Level.PASS
+    assert _check(report.servers, "stub", "initialize").level is Level.PASS
+    tools = _check(report.servers, "stub", "tools-list")
+    assert tools.level is Level.PASS
+    assert "echo" in tools.data["tools"]
+    assert not report.failed
+
+
+@pytest.mark.asyncio
+async def test_empty_server_fails_tools_and_aggregate():
+    spec = ServerSpec(name="empty", command=sys.executable, args=[STUB, "empty"])
+    report = await run_config(_config(spec), RunOptions())
+
+    assert _check(report.servers, "empty", "tools-list").level is Level.FAIL
+    agg = next(c for c in report.aggregate if c.id == "aggregate.tools")
+    assert agg.level is Level.FAIL
+    assert report.failed
+
+
+@pytest.mark.asyncio
+async def test_nonexistent_command_fails_spawn():
+    spec = ServerSpec(name="missing", command="/nonexistent/please/no", args=[])
+    report = await run_config(_config(spec), RunOptions())
+
+    assert _check(report.servers, "missing", "spawn").level is Level.FAIL
+    assert report.failed
+
+
+@pytest.mark.asyncio
+async def test_active_tool_call():
+    spec = ServerSpec(name="stub", command=sys.executable, args=[STUB, "good"])
+    opts = RunOptions(calls=[CallRequest(tool="echo", arguments={"text": "hi"})])
+    report = await run_config(_config(spec), opts)
+
+    call = _check(report.servers, "stub", "call:echo")
+    assert call.level is Level.PASS
+    assert not report.failed
+
+
+@pytest.mark.asyncio
+async def test_probe_tools_calls_no_arg_tools():
+    spec = ServerSpec(name="stub", command=sys.executable, args=[STUB, "good"])
+    report = await run_config(_config(spec), RunOptions(probe_tools=True))
+
+    # ``ping`` has no required args and should have been probed; ``echo`` requires
+    # ``text`` so it should be skipped.
+    ids = {c.id for s in report.servers for c in s.results}
+    assert "call:ping" in ids
+    assert "call:echo" not in ids
+
+
+@pytest.mark.asyncio
+async def test_good_server_both_latency_checks_pass():
+    spec = ServerSpec(name="stub", command=sys.executable, args=[STUB, "good"])
+    report = await run_config(_config(spec), RunOptions())
+
+    assert _check(report.servers, "stub", "initialize-latency").level is Level.PASS
+    assert _check(report.servers, "stub", "tools-list-latency").level is Level.PASS
+
+
+@pytest.mark.asyncio
+async def test_slow_list_fails_tools_list_latency():
+    # tools/list takes ~6 s (> the 5 s budget) -> FAIL.
+    spec = ServerSpec(name="slow", command=sys.executable, args=[STUB, "slow-list", "6"])
+    report = await run_config(_config(spec), RunOptions())
+
+    assert _check(report.servers, "slow", "tools-list-latency").level is Level.FAIL
+    # initialize itself was fast, so that check should not FAIL.
+    assert _check(report.servers, "slow", "initialize-latency").level is not Level.FAIL
+    assert report.failed
+
+
+@pytest.mark.asyncio
+async def test_slow_init_warns_but_does_not_fail():
+    # spawn+initialize takes ~6 s; the service does not time this out, so it is a WARN
+    # and the overall run is NOT failed (tools still list fine afterwards).
+    spec = ServerSpec(name="slowi", command=sys.executable, args=[STUB, "slow-init", "6"])
+    report = await run_config(_config(spec), RunOptions())
+
+    assert _check(report.servers, "slowi", "initialize-latency").level is Level.WARN
+    assert _check(report.servers, "slowi", "tools-list-latency").level is Level.PASS
+    assert _check(report.servers, "slowi", "tools-list").level is Level.PASS
+    assert not report.failed


### PR DESCRIPTION
## Summary

Adds `utils/mcpforwardingtester`, a small Python CLI that checks whether the MCP servers you configure for tool forwarding on WorkSpaces Applications will work, before you build a fleet image. It reproduces how the service launches and queries your servers and reports, per server, what passes and what to fix. This catches failures that otherwise only surface after a long image build: a server that lists no tools, a config saved with a BOM, ignored `env`/`cwd`, or a `tools/list` that exceeds the 5 second budget.

## What's added

- `utils/mcpforwardingtester/`: the package, run as `py -m mcp_forwarding_tester` (or the `mcp-forwarding-test` command). Two modes: `config` (validate the deployed config, default path resolved automatically) and `server` (test a single server ad hoc), with `--json` output for a build gate and a per-server PASS/WARN/FAIL report.
- Python 3.10+, one runtime dependency (the `mcp` SDK).
- A README with install and usage.
- Root `README.md`: added the package to the project structure and a pointer from the tool forwarding section.

## Testing

- 19 pytest cases pass: happy path, zero-tools FAIL, missing-executable FAIL, active tool calls, and the latency split.
- Verified end to end on a WorkSpaces Applications Windows Server 2022 image builder: installed from the repo archive in PowerShell and validated a sample config to an `OK` verdict.
- `pyflakes` clean; `scripts/ci_local.sh` passes.

## Follow-up

A separate PR will align the existing "MCP redirection" naming across the repo to "MCP tool forwarding."
