### PR TITLE
fix: restore MCP config exports for multi-agent validation

### DIFF
--- a/lib/agent_common.py
+++ b/lib/agent_common.py
@@ -23,6 +23,8 @@ from .screenshot_pruning_manager import ScreenshotPruningConversationManager
 # Re-exports from sub-modules
 from .model import ALLOWED_REGIONS, _supports_converse_images, create_model
 from .mcp_client import (
+    _config,
+    _is_remote_mcp,
     DEFAULT_MCP_ENDPOINT,
     DEFAULT_MCP_REGION_OVERRIDE,
     DEFAULT_MCP_SERVICE,


### PR DESCRIPTION
  ## Summary

  - Re-export `_config` and `_is_remote_mcp` from `lib.agent_common`
  - Fix `AttributeError` during multi-agent validation startup

  ## Testing

  - Ran `PYTHON_CMD=.venv/bin/python ./scripts/ci_local.sh`
  - Verified the multi-agent validation startup passes the previous attribute access failure