### PR TITLE
fix: use documented Domain Join metadata keys

### DIFF
--- a/lib/mcp_client.py
+++ b/lib/mcp_client.py
@@ -93,8 +93,8 @@ def create_mcp_client_factory(args, root_dir=None):
         sys.stdout.flush()
 
         meta_values = {
-            "aws.agentaccess/workspacesApplicationsSamlAssertion": saml_assertion,
-            "aws.agentaccess/workspacesApplicationsStackArn": stack_arn,
+            "saml_response": saml_assertion,
+            "stack_arn": stack_arn,
         }
 
         def factory():


### PR DESCRIPTION
  ## Summary

  - Send `saml_response` and `stack_arn` in the MCP `_meta` field
  - Replace the old namespaced Domain Join metadata keys

  ## Testing

  - Ran `PYTHON_CMD=.venv/bin/python ./scripts/ci_local.sh`
  - Verified the Domain Join transport sends the expected metadata
  - Verified the streaming URL path and missing Stack ARN validation are unchanged